### PR TITLE
update loop method for yum, apt and pip tasks

### DIFF
--- a/roles/ansible-engine/tasks/main.yml
+++ b/roles/ansible-engine/tasks/main.yml
@@ -31,13 +31,12 @@
 - name: install python winrm and kerberos dependencies
   become: true
   pip:
-    name: "{{ item }}"
-  with_items:
-    - pywinrm
-    - pywinrm[kerberos]
-    - pykerberos>=1.2.1
-    - requests-kerberos
-    - requests-ntlm
+    name:
+      - pywinrm
+      - pywinrm[kerberos]
+      - pykerberos>=1.2.1
+      - requests-kerberos
+      - requests-ntlm
 
 - name: Configure Kerberos reamls
   become: true
@@ -63,10 +62,9 @@
 - name: install napalm-ansible
   become: true
   pip:
-    name: "{{ item }}"
-  with_items: 
-    - napalm-ansible
-    - python-gssapi
+    name:
+      - napalm-ansible
+      - python-gssapi
 
 - name: install network address filter
   become: true
@@ -76,30 +74,27 @@
 - name: install F5 dependencies
   become: true
   pip:
-    name: "{{ item }}"
-  with_items:
-    - f5-sdk
-    - bigsuds
-    - deepdiff
+    name:
+      - f5-sdk
+      - bigsuds
+      - deepdiff
 
 - name: install AWS dependencies
   become: true
   pip:
-    name: "{{ item }}"
-  with_items:
-    - boto
-    - boto3
-    - botocore
+    name:
+      - boto
+      - boto3
+      - botocore
 
 - name: install Google Cloud dependencies
   become: true
   pip:
-    name: "{{ item }}"
-  with_items:
-    - apache-libcloud
-    - boto
-    - google-auth
-    - google-cloud-pubsub
+    name:
+      - apache-libcloud
+      - boto
+      - google-auth
+      - google-cloud-pubsub
 
 
 # Upgrade ansible to latest stable version published in EPEL repo

--- a/roles/vscode/tasks/setup-Debian.yml
+++ b/roles/vscode/tasks/setup-Debian.yml
@@ -3,11 +3,10 @@
 - name: install vscode dependencies
   become: true
   apt:
-    name: "{{ item }}"
+    name:
+      - ca-certificates
+      - apt-transport-https
     state: present
-  with_items:
-    - ca-certificates
-    - apt-transport-https
 
 - name:  import microsoft packages key
   become: true

--- a/roles/xrdp/tasks/setup-RedHat.yml
+++ b/roles/xrdp/tasks/setup-RedHat.yml
@@ -9,13 +9,12 @@
 - name: install xrdp
   become: true
   yum:
-    name: "{{ item }}"
+    name:
+      - xrdp
+      - tigervnc-server
     state: present
     enablerepo: cr
-  with_items:
-    - xrdp
-    - tigervnc-server
-
+  
 - name: start and enable xrdp service
   become: true
   service:


### PR DESCRIPTION
Loop via squash_actions is deprecated for yum,apt and pip modules. Instead of using a loop to supply multiple items and specifying `name: {{ item }}` / "with_items:", updated tasks to use `name: [u'item1', u'item2', u'item3']` and removed the loop. 